### PR TITLE
Added rainbow in background and dial-up simulator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,7 +64,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lolcat"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/cat.rs
+++ b/src/cat.rs
@@ -15,6 +15,7 @@ pub struct Control {
 pub fn print_with_lolcat(s: String, c: &mut Control) {
     let original_seed = c.seed;
     let mut skipping = false;
+    let mut whitespace_after_newline = true;
 
     for character in s.chars() {
         // Strip out any color chars
@@ -27,6 +28,15 @@ pub fn print_with_lolcat(s: String, c: &mut Control) {
             continue;
         }
         if skipping {
+            continue;
+        }
+
+        if !character.is_whitespace() {
+            whitespace_after_newline = false;
+        }
+
+        if whitespace_after_newline {
+            print!("{}", character);
             continue;
         }
 

--- a/src/cat.rs
+++ b/src/cat.rs
@@ -1,10 +1,18 @@
+extern crate rand;
+
 use std;
+use std::thread::sleep;
+use std::time::Duration;
+
+use rand::Rng;
 
 // A struct to contain info we need to print with every character
 pub struct Control {
     pub seed: f64,
     pub spread: f64,
     pub frequency: f64,
+    pub background_mode: bool,
+    pub dialup_mode: bool,
 }
 
 // A wrapper around colored_print
@@ -28,20 +36,68 @@ pub fn print_with_lolcat(s: String, c: &mut Control) {
 
         c.seed += 1.0;
 
-        if character == ' ' {
-            print!(" ");
-            continue;
+        if c.dialup_mode && character.is_whitespace() {
+            let stall = Duration::from_millis(rand::thread_rng().gen_range(0, 30));
+            sleep(stall);
         }
-        colored_print(get_color_tuple(c), character);
+
+        if c.background_mode {
+            let bg = get_color_tuple(c);
+            let fg = if conv_grayscale(bg) > 0xA0_u8 {
+                (0u8, 0u8, 0u8)
+            } else {
+                (0xffu8, 0xffu8, 0xffu8)
+            };
+            colored_print(fg, bg, character);
+        } else {
+            let fg = get_color_tuple(c);
+            let black = (0u8, 0u8, 0u8);
+            colored_print(fg, black, character);
+        }
     }
+
     print!("\n"); // A newline, because lines() gave us a single line without it
     c.seed = original_seed + 1.0; // Reset the seed, but bump it a bit
 }
 
-fn colored_print(colors: (u8, u8, u8), c: char) {
+fn linear_to_srgb(intensity: f64) -> f64 {
+    if intensity <= 0.0031308 {
+        (12.92 * intensity)
+    } else {
+        (1.055 * intensity.powf(1.0 / 2.4) - 0.055)
+    }
+}
+
+fn srgb_to_linear(intensity: f64) -> f64 {
+    if intensity < 0.04045 {
+        (intensity / 12.92)
+    } else {
+        ((intensity + 0.055) / 1.055).powf(2.4)
+    }
+}
+
+fn conv_grayscale(color: (u8, u8, u8)) -> u8 {
+    // See https://en.wikipedia.org/wiki/Grayscale#Converting_color_to_grayscale
+    const SCALE : f64 = 256.0;
+
+    // Changing SRGB to Linear for gamma correction
+    let red = srgb_to_linear((color.0 as f64) / SCALE);
+    let green = srgb_to_linear((color.1 as f64) / SCALE);
+    let blue = srgb_to_linear((color.2 as f64) / SCALE);
+
+    // Converting to grayscale
+    let gray_linear = red * 0.299 + green * 0.587 + blue * 0.114;
+
+    // Gamma correction
+    let gray_srgb = linear_to_srgb(gray_linear);
+
+    (gray_srgb * SCALE) as u8
+}
+
+fn colored_print(fg: (u8, u8, u8), bg: (u8, u8, u8), c: char) {
     print!(
-        "\x1b[38;2;{};{};{}m{}\x1b[0m",
-        colors.0, colors.1, colors.2, c
+        "\x1b[38;2;{};{};{};48;2;{};{};{}m{}\x1b[0m",
+        fg.0, fg.1, fg.2, bg.0, bg.1, bg.2, c
     );
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,6 +62,20 @@ fn parse_cli_args(filename: &mut String) -> cat::Control {
                 .takes_value(true),
         )
         .arg(
+            Arg::with_name("background")
+                .short("B")
+                .long("bg")
+                .help("Background mode - If selected the background will be rainbow. Default false")
+                .takes_value(false),
+        )
+        .arg(
+            Arg::with_name("dialup")
+                .short("D")
+                .long("dialup")
+                .help("Dialup mode - Simulate dialup connection")
+                .takes_value(false),
+        )
+        .arg(
             Arg::with_name("filename")
                 .short("i")
                 .long("input file name")
@@ -70,9 +84,13 @@ fn parse_cli_args(filename: &mut String) -> cat::Control {
                 .index(1),
         )
         .get_matches();
+
     let seed = matches.value_of("seed").unwrap_or("0.0");
     let spread = matches.value_of("spread").unwrap_or("3.0");
     let frequency = matches.value_of("frequency").unwrap_or("0.1");
+    let background = matches.is_present("background");
+    let dialup = matches.is_present("dialup");
+
     *filename = matches.value_of("filename").unwrap_or("").to_string();
 
     let mut seed: f64 = seed.parse().unwrap();
@@ -87,5 +105,7 @@ fn parse_cli_args(filename: &mut String) -> cat::Control {
         seed: seed,
         spread: spread,
         frequency: frequency,
+        background_mode: background,
+        dialup_mode: dialup,
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,13 @@
-use std::io;
-
 extern crate clap;
 extern crate rand;
 use clap::{App, Arg};
+use rand::Rng;
 use std::fs::File;
+use std::io;
 use std::io::BufRead;
 use std::io::BufReader;
+use std::thread::sleep;
+use std::time::Duration;
 
 mod cat;
 
@@ -17,6 +19,10 @@ fn main() {
     if filename == "" {
         for line in stdin.lock().lines() {
             cat::print_with_lolcat(line.unwrap(), &mut c);
+            if c.dialup_mode {
+                let stall = Duration::from_millis(rand::thread_rng().gen_range(30, 200));
+                sleep(stall);
+            }
         }
     } else {
         match lolcat_file(&filename, &mut c) {
@@ -31,6 +37,11 @@ fn lolcat_file(filename: &String, c: &mut cat::Control) -> Result<(), io::Error>
     let file = BufReader::new(&f);
     for line in file.lines() {
         cat::print_with_lolcat(line.unwrap(), c);
+
+        if c.dialup_mode {
+            let stall = Duration::from_millis(rand::thread_rng().gen_range(30, 700));
+            sleep(stall);
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
With --bg or -B flag, one can place the rainbow in the background.

With --dialup or -D flag, one can simulate the pain of 90's internet with simulating dial-up connection.