### PR TITLE
Remove setting background color without a color

### DIFF
--- a/src/cat.rs
+++ b/src/cat.rs
@@ -102,7 +102,7 @@ fn conv_grayscale(color: (u8, u8, u8)) -> u8 {
 }
 
 fn colored_print(fg: (u8, u8, u8), c: char) {
-    print!("\x1b[38;2;{};{};{};48m{}\x1b[0m", fg.0, fg.1, fg.2, c);
+    print!("\x1b[38;2;{};{};{}m{}\x1b[0m", fg.0, fg.1, fg.2, c);
 }
 
 fn colored_print_with_background(fg: (u8, u8, u8), bg: (u8, u8, u8), c: char) {


### PR DESCRIPTION
The line `print!("\x1b[38;2;{};{};{};48m{}\x1b[0m", fg.0, fg.1, fg.2, c);` includes `48m`. From [wikipedia](https://en.wikipedia.org/wiki/ANSI_escape_code#Colors) the `48` code needs to be followed by either `;5;n` where `n` is a color code or `;2;r;g;b` with rgb values as you have done in `colored_print_with_background`. It looks like a trailing `48m` just results in a black background by default in at least KDE's Konsole terminal. This PR just removes the trailing 48.