### PR TITLE
Intelligent wrap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,11 +4,11 @@ version = 3
 
 [[package]]
 name = "ansi_term"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -25,7 +25,7 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -42,9 +42,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "ansi_term",
  "atty",
@@ -76,26 +76,43 @@ dependencies = [
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.108"
+name = "kernel32-sys"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8521a1b57e76b1ec69af7599e75e38e7b7fad6610f037db8c79b127201b5d119"
+checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.139"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "lolcat"
-version = "1.4.1"
+version = "1.5.0"
 dependencies = [
  "atty",
  "clap",
  "rand",
+ "termsize",
  "utf8-chars",
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.15"
+name = "numtoa"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
+checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "rand"
@@ -139,10 +156,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_termios"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8440d8acb4fd3d277125b4bd01a6f38aee8d814b3b5fc09b3f2b825d37d3fe8f"
+dependencies = [
+ "redox_syscall",
+]
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "termion"
+version = "1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "077185e2eac69c3f8379a4298e1e07cd36beb962290d4a51199acf0fdc10607e"
+dependencies = [
+ "libc",
+ "numtoa",
+ "redox_syscall",
+ "redox_termios",
+]
+
+[[package]]
+name = "termsize"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e86d824a8e90f342ad3ef4bd51ef7119a9b681b0cc9f8ee7b2852f02ccd2517"
+dependencies = [
+ "atty",
+ "kernel32-sys",
+ "libc",
+ "termion",
+ "winapi 0.2.8",
+]
 
 [[package]]
 name = "textwrap"
@@ -155,9 +215,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "utf8-chars"
@@ -182,6 +242,12 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+
+[[package]]
+name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
@@ -189,6 +255,12 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lolcat"
-version = "1.4.1"
+version = "1.5.0"
 authors = ["Umang Raghuvanshi <u@umangis.me>"]
 description = "The good ol' lolcat, now with fearless concurrency."
 license = "MIT"
@@ -11,3 +11,4 @@ clap = "2.33.0"
 rand = "0.7.3"
 atty = "0.2"
 utf8-chars = "1.0.2"
+termsize = "0.1.6"

--- a/src/cat.rs
+++ b/src/cat.rs
@@ -10,221 +10,226 @@ use std::io::Write;
 
 // A struct to contain info we need to print with every character
 pub struct Control {
-    pub seed: f64,
-    pub spread: f64,
-    pub frequency: f64,
-    pub background_mode: bool,
-    pub dialup_mode: bool,
-    pub print_color: bool,
+	pub seed: f64,
+	pub spread: f64,
+	pub frequency: f64,
+	pub background_mode: bool,
+	pub dialup_mode: bool,
+	pub print_color: bool,
 }
 
 // This used to have more of a reason to exist, however now all its functionality is in
 // print_chars_lol(). It takes in an iterator over lines and prints them all.
 // At the end, it resets the foreground color
-pub fn print_lines_lol<I: Iterator<Item=S>, S: AsRef<str>>(lines: I, c: &mut Control) {
-    for line in lines {
-        print_chars_lol(line.as_ref().chars().chain(Some('\n')), c, false);
-    }
-    if c.print_color {
-        print!("\x1b[39m");
-    }
+pub fn print_lines_lol<I: Iterator<Item = S>, S: AsRef<str>>(lines: I, c: &mut Control) {
+	for line in lines {
+		print_chars_lol(line.as_ref().chars().chain(Some('\n')), c, false);
+	}
+	if c.print_color {
+		print!("\x1b[39m");
+	}
 }
 
 // Takes in s an iterator over characters
 // duplicates escape sequences, otherwise prints printable characters with colored_print
 // Print newlines correctly, resetting background
 // If constantly_flush is on, it won't wait till a newline to flush stdout
-pub fn print_chars_lol<I: Iterator<Item=char>>(mut iter: I, c: &mut Control, constantly_flush: bool) {
-    let mut original_seed = c.seed;
-    let mut ignore_whitespace = c.background_mode;
+pub fn print_chars_lol<I: Iterator<Item = char>>(
+	mut iter: I,
+	c: &mut Control,
+	constantly_flush: bool,
+) {
+	let mut original_seed = c.seed;
+	let mut ignore_whitespace = c.background_mode;
 
-    if !c.print_color {
-        for character in iter {
-            print!("{}", character);
-        }
-        return;
-    }
+	if !c.print_color {
+		for character in iter {
+			print!("{}", character);
+		}
+		return;
+	}
 
-    while let Some(character) = iter.next() {
-        match character {
-        // Consume escape sequences
-        '\x1b' => {
-            // Escape sequences seem to be one of many different categories: https://en.wikipedia.org/wiki/ANSI_escape_code
-            // CSI sequences are \e \[ [bytes in 0x30-0x3F] [bytes in 0x20-0x2F] [final byte in 0x40-0x7E]
-            // nF Escape seq are \e [bytes in 0x20-0x2F] [byte in 0x30-0x7E]
-            // Fp Escape seq are \e [byte in 0x30-0x3F] [I have no idea, but `sl` creates one where the next byte is the end of the escape sequence, so assume that]
-            // Fe Escape seq are \e [byte in 0x40-0x5F] [I have no idea, '' though sl doesn't make one]
-            // Fs Escape seq are \e [byte in 0x60-0x7E] [I have no idea, '' though sl doesn't make one]
-            // Otherwise the next byte is the whole escape sequence (maybe? I can't exactly tell, but I will go with it)
-            // We will consume up to, but not through, the next printable character
-            // In addition, we print everything in the escape sequence, even if it is a color (that will be overriden)
-            print!("\x1b");
-            let mut escape_sequence_character = iter.next().expect("Escape character with no escape sequence after it");
-            print!("{}", escape_sequence_character);
-            match escape_sequence_character {
-            '[' => {
-                loop {
-                    escape_sequence_character = iter.next().expect("CSI escape sequence did not terminate");
-                    print!("{}", escape_sequence_character);
-                    match escape_sequence_character {
-                    '\x30' ..= '\x3F' => continue,
-                    '\x20' ..= '\x2F' => {
-                        loop {
-                            escape_sequence_character = iter.next().expect("CSI escape sequence did not terminate");
-                            print!("{}", escape_sequence_character);
-                            match escape_sequence_character {
+	while let Some(character) = iter.next() {
+		match character {
+			// Consume escape sequences
+			'\x1b' => {
+				// Escape sequences seem to be one of many different categories: https://en.wikipedia.org/wiki/ANSI_escape_code
+				// CSI sequences are \e \[ [bytes in 0x30-0x3F] [bytes in 0x20-0x2F] [final byte in 0x40-0x7E]
+				// nF Escape seq are \e [bytes in 0x20-0x2F] [byte in 0x30-0x7E]
+				// Fp Escape seq are \e [byte in 0x30-0x3F] [I have no idea, but `sl` creates one where the next byte is the end of the escape sequence, so assume that]
+				// Fe Escape seq are \e [byte in 0x40-0x5F] [I have no idea, '' though sl doesn't make one]
+				// Fs Escape seq are \e [byte in 0x60-0x7E] [I have no idea, '' though sl doesn't make one]
+				// Otherwise the next byte is the whole escape sequence (maybe? I can't exactly tell, but I will go with it)
+				// We will consume up to, but not through, the next printable character
+				// In addition, we print everything in the escape sequence, even if it is a color (that will be overriden)
+				print!("\x1b");
+				let mut escape_sequence_character = iter
+					.next()
+					.expect("Escape character with no escape sequence after it");
+				print!("{}", escape_sequence_character);
+				match escape_sequence_character {
+					'[' => loop {
+						escape_sequence_character =
+							iter.next().expect("CSI escape sequence did not terminate");
+						print!("{}", escape_sequence_character);
+						match escape_sequence_character {
+							'\x30'..='\x3F' => continue,
+							'\x20'..='\x2F' => {
+								loop {
+									escape_sequence_character =
+										iter.next().expect("CSI escape sequence did not terminate");
+									print!("{}", escape_sequence_character);
+									match escape_sequence_character {
                             '\x20' ..= '\x2F' => continue,
                             '\x40' ..= '\x7E' => break,
                             _ => panic!("CSI escape sequence terminated with an incorrect value"),
                             }
-                        }
-                        break;
-                    },
-                    '\x40' ..= '\x7E' => break,
-                    _ => panic!("CSI escape sequence terminated with an incorrect value"),
-                    }
-                }
-            },
-            '\x20' ..= '\x2F' => {
-                loop {
-                    escape_sequence_character = iter.next().expect("nF escape sequence did not terminate");
-                    print!("{}", escape_sequence_character);
-                    match escape_sequence_character {
-                    '\x20' ..= '\x2F' => continue,
-                    '\x30' ..= '\x7E' => break,
-                    _ => panic!("nF escape sequence terminated with an incorrect value"),
-                    }
-                }
-            },
-//            '\x30' ..= '\x3F' => panic!("Fp escape sequences are not supported"),
-//            '\x40' ..= '\x5F' => panic!("Fe escape sequences are not supported"),
-//            '\x60' ..= '\x7E' => panic!("Fs escape sequences are not supported"),
-            // be lazy and assume in all other cases we consume exactly 1 byte
-            _ => (),
-            }
-        },
-        // Newlines print escape sequences to end background prints, and in dialup mode sleep, and
-        // reset the seed of the coloring and the value of ignore_whitespace
-        '\n' => {
-            if c.print_color {
-                // Reset the background color only, as we don't have to reset the foreground till
-                // the end of the program
-                // We reset the background here because otherwise it bleeds all the way to the next line
-                if c.background_mode {
-                    print!("\x1b[49m");
-                }
-            }
-            println!();
-            if c.dialup_mode {
-                let stall = Duration::from_millis(rand::thread_rng().gen_range(30, 700));
-                sleep(stall);
-            }
+								}
+								break;
+							}
+							'\x40'..='\x7E' => break,
+							_ => panic!("CSI escape sequence terminated with an incorrect value"),
+						}
+					},
+					'\x20'..='\x2F' => loop {
+						escape_sequence_character =
+							iter.next().expect("nF escape sequence did not terminate");
+						print!("{}", escape_sequence_character);
+						match escape_sequence_character {
+							'\x20'..='\x2F' => continue,
+							'\x30'..='\x7E' => break,
+							_ => panic!("nF escape sequence terminated with an incorrect value"),
+						}
+					},
+					//            '\x30' ..= '\x3F' => panic!("Fp escape sequences are not supported"),
+					//            '\x40' ..= '\x5F' => panic!("Fe escape sequences are not supported"),
+					//            '\x60' ..= '\x7E' => panic!("Fs escape sequences are not supported"),
+					// be lazy and assume in all other cases we consume exactly 1 byte
+					_ => (),
+				}
+			}
+			// Newlines print escape sequences to end background prints, and in dialup mode sleep, and
+			// reset the seed of the coloring and the value of ignore_whitespace
+			'\n' => {
+				if c.print_color {
+					// Reset the background color only, as we don't have to reset the foreground till
+					// the end of the program
+					// We reset the background here because otherwise it bleeds all the way to the next line
+					if c.background_mode {
+						print!("\x1b[49m");
+					}
+				}
+				println!();
+				if c.dialup_mode {
+					let stall = Duration::from_millis(rand::thread_rng().gen_range(30, 700));
+					sleep(stall);
+				}
 
-            original_seed += 1.0;
-            c.seed = original_seed; // Reset the seed, but bump it a bit
-            ignore_whitespace = c.background_mode;
-        },
-        // If not an escape sequence or a newline, print a colorful escape sequence and then the
-        // character
-        _ => {
-            // In background mode, don't print colorful whitespace until the first printable character
-            if ignore_whitespace && character.is_whitespace() {
-                print!("{}", character);
-                continue;
-            } else {
-                ignore_whitespace = false;
-            }
+				original_seed += 1.0;
+				c.seed = original_seed; // Reset the seed, but bump it a bit
+				ignore_whitespace = c.background_mode;
+			}
+			// If not an escape sequence or a newline, print a colorful escape sequence and then the
+			// character
+			_ => {
+				// In background mode, don't print colorful whitespace until the first printable character
+				if ignore_whitespace && character.is_whitespace() {
+					print!("{}", character);
+					continue;
+				} else {
+					ignore_whitespace = false;
+				}
 
-            colored_print(character, c);
-            c.seed += 1.0;
-        },
-        }
+				colored_print(character, c);
+				c.seed += 1.0;
+			}
+		}
 
-        // If we should constantly flush, flush after each completed sequence, and also reset
-        // colors because otherwise weird things happen
-        if constantly_flush {
-            reset_colors(c);
-            stdout().flush().unwrap();
-        }
-    }
+		// If we should constantly flush, flush after each completed sequence, and also reset
+		// colors because otherwise weird things happen
+		if constantly_flush {
+			reset_colors(c);
+			stdout().flush().unwrap();
+		}
+	}
 }
 
 fn reset_colors(c: &Control) {
-    if c.print_color {
-        // Reset the background color
-        if c.background_mode {
-            print!("\x1b[49m");
-        }
+	if c.print_color {
+		// Reset the background color
+		if c.background_mode {
+			print!("\x1b[49m");
+		}
 
-        // Reset the foreground color
-        print!("\x1b[39m");
-    }
+		// Reset the foreground color
+		print!("\x1b[39m");
+	}
 }
 
 fn colored_print(character: char, c: &mut Control) {
-    if c.background_mode {
-        let bg = get_color_tuple(c);
-        let fg = calc_fg_color(bg);
-        print!(
-            "\x1b[38;2;{};{};{};48;2;{};{};{}m{}",
-            fg.0, fg.1, fg.2, bg.0, bg.1, bg.2, character
-        );
-    } else {
-        let fg = get_color_tuple(c);
-        print!("\x1b[38;2;{};{};{}m{}", fg.0, fg.1, fg.2, character);
-    }
+	if c.background_mode {
+		let bg = get_color_tuple(c);
+		let fg = calc_fg_color(bg);
+		print!(
+			"\x1b[38;2;{};{};{};48;2;{};{};{}m{}",
+			fg.0, fg.1, fg.2, bg.0, bg.1, bg.2, character
+		);
+	} else {
+		let fg = get_color_tuple(c);
+		print!("\x1b[38;2;{};{};{}m{}", fg.0, fg.1, fg.2, character);
+	}
 }
 
 fn calc_fg_color(bg: (u8, u8, u8)) -> (u8, u8, u8) {
-    // Currently, it only computes the forground clolor based on some threshold
-    // on grayscale value.
-    // TODO: Add a better algorithm for computing forground color
-    if conv_grayscale(bg) > 0xA0_u8 {
-        (0u8, 0u8, 0u8)
-    } else {
-        (0xffu8, 0xffu8, 0xffu8)
-    }
+	// Currently, it only computes the forground clolor based on some threshold
+	// on grayscale value.
+	// TODO: Add a better algorithm for computing forground color
+	if conv_grayscale(bg) > 0xA0_u8 {
+		(0u8, 0u8, 0u8)
+	} else {
+		(0xffu8, 0xffu8, 0xffu8)
+	}
 }
 
 fn linear_to_srgb(intensity: f64) -> f64 {
-    if intensity <= 0.003_130_8 {
-        12.92 * intensity
-    } else {
-        1.055 * intensity.powf(1.0 / 2.4) - 0.055
-    }
+	if intensity <= 0.003_130_8 {
+		12.92 * intensity
+	} else {
+		1.055 * intensity.powf(1.0 / 2.4) - 0.055
+	}
 }
 
 fn srgb_to_linear(intensity: f64) -> f64 {
-    if intensity < 0.04045 {
-        intensity / 12.92
-    } else {
-        ((intensity + 0.055) / 1.055).powf(2.4)
-    }
+	if intensity < 0.04045 {
+		intensity / 12.92
+	} else {
+		((intensity + 0.055) / 1.055).powf(2.4)
+	}
 }
 
 fn conv_grayscale(color: (u8, u8, u8)) -> u8 {
-    // See https://en.wikipedia.org/wiki/Grayscale#Converting_color_to_grayscale
-    const SCALE: f64 = 256.0;
+	// See https://en.wikipedia.org/wiki/Grayscale#Converting_color_to_grayscale
+	const SCALE: f64 = 256.0;
 
-    // Changing SRGB to Linear for gamma correction
-    let red = srgb_to_linear(f64::from(color.0) / SCALE);
-    let green = srgb_to_linear(f64::from(color.1) / SCALE);
-    let blue = srgb_to_linear(f64::from(color.2) / SCALE);
+	// Changing SRGB to Linear for gamma correction
+	let red = srgb_to_linear(f64::from(color.0) / SCALE);
+	let green = srgb_to_linear(f64::from(color.1) / SCALE);
+	let blue = srgb_to_linear(f64::from(color.2) / SCALE);
 
-    // Converting to grayscale
-    let gray_linear = red * 0.299 + green * 0.587 + blue * 0.114;
+	// Converting to grayscale
+	let gray_linear = red * 0.299 + green * 0.587 + blue * 0.114;
 
-    // Gamma correction
-    let gray_srgb = linear_to_srgb(gray_linear);
+	// Gamma correction
+	let gray_srgb = linear_to_srgb(gray_linear);
 
-    (gray_srgb * SCALE) as u8
+	(gray_srgb * SCALE) as u8
 }
 
 fn get_color_tuple(c: &Control) -> (u8, u8, u8) {
-    let i = c.frequency * c.seed / c.spread;
-    let red = i.sin() * 127.00 + 128.00;
-    let green = (i + (std::f64::consts::PI * 2.00 / 3.00)).sin() * 127.00 + 128.00;
-    let blue = (i + (std::f64::consts::PI * 4.00 / 3.00)).sin() * 127.00 + 128.00;
+	let i = c.frequency * c.seed / c.spread;
+	let red = i.sin() * 127.00 + 128.00;
+	let green = (i + (std::f64::consts::PI * 2.00 / 3.00)).sin() * 127.00 + 128.00;
+	let blue = (i + (std::f64::consts::PI * 4.00 / 3.00)).sin() * 127.00 + 128.00;
 
-    (red as u8, green as u8, blue as u8)
+	(red as u8, green as u8, blue as u8)
 }

--- a/src/cat.rs
+++ b/src/cat.rs
@@ -10,24 +10,24 @@ use std::io::Write;
 
 // A struct to contain info we need to print with every character
 pub struct Control {
-	pub seed: f64,
-	pub spread: f64,
-	pub frequency: f64,
-	pub background_mode: bool,
-	pub dialup_mode: bool,
-	pub print_color: bool,
+    pub seed: f64,
+    pub spread: f64,
+    pub frequency: f64,
+    pub background_mode: bool,
+    pub dialup_mode: bool,
+    pub print_color: bool,
 }
 
 // This used to have more of a reason to exist, however now all its functionality is in
 // print_chars_lol(). It takes in an iterator over lines and prints them all.
 // At the end, it resets the foreground color
 pub fn print_lines_lol<I: Iterator<Item = S>, S: AsRef<str>>(lines: I, c: &mut Control) {
-	for line in lines {
-		print_chars_lol(line.as_ref().chars().chain(Some('\n')), c, false);
-	}
-	if c.print_color {
-		print!("\x1b[39m");
-	}
+    for line in lines {
+        print_chars_lol(line.as_ref().chars().chain(Some('\n')), c, false);
+    }
+    if c.print_color {
+        print!("\x1b[39m");
+    }
 }
 
 // Takes in s an iterator over characters
@@ -35,201 +35,201 @@ pub fn print_lines_lol<I: Iterator<Item = S>, S: AsRef<str>>(lines: I, c: &mut C
 // Print newlines correctly, resetting background
 // If constantly_flush is on, it won't wait till a newline to flush stdout
 pub fn print_chars_lol<I: Iterator<Item = char>>(
-	mut iter: I,
-	c: &mut Control,
-	constantly_flush: bool,
+    mut iter: I,
+    c: &mut Control,
+    constantly_flush: bool,
 ) {
-	let mut original_seed = c.seed;
-	let mut ignore_whitespace = c.background_mode;
+    let mut original_seed = c.seed;
+    let mut ignore_whitespace = c.background_mode;
 
-	if !c.print_color {
-		for character in iter {
-			print!("{}", character);
-		}
-		return;
-	}
+    if !c.print_color {
+        for character in iter {
+            print!("{}", character);
+        }
+        return;
+    }
 
-	while let Some(character) = iter.next() {
-		match character {
-			// Consume escape sequences
-			'\x1b' => {
-				// Escape sequences seem to be one of many different categories: https://en.wikipedia.org/wiki/ANSI_escape_code
-				// CSI sequences are \e \[ [bytes in 0x30-0x3F] [bytes in 0x20-0x2F] [final byte in 0x40-0x7E]
-				// nF Escape seq are \e [bytes in 0x20-0x2F] [byte in 0x30-0x7E]
-				// Fp Escape seq are \e [byte in 0x30-0x3F] [I have no idea, but `sl` creates one where the next byte is the end of the escape sequence, so assume that]
-				// Fe Escape seq are \e [byte in 0x40-0x5F] [I have no idea, '' though sl doesn't make one]
-				// Fs Escape seq are \e [byte in 0x60-0x7E] [I have no idea, '' though sl doesn't make one]
-				// Otherwise the next byte is the whole escape sequence (maybe? I can't exactly tell, but I will go with it)
-				// We will consume up to, but not through, the next printable character
-				// In addition, we print everything in the escape sequence, even if it is a color (that will be overriden)
-				print!("\x1b");
-				let mut escape_sequence_character = iter
-					.next()
-					.expect("Escape character with no escape sequence after it");
-				print!("{}", escape_sequence_character);
-				match escape_sequence_character {
-					'[' => loop {
-						escape_sequence_character =
-							iter.next().expect("CSI escape sequence did not terminate");
-						print!("{}", escape_sequence_character);
-						match escape_sequence_character {
-							'\x30'..='\x3F' => continue,
-							'\x20'..='\x2F' => {
-								loop {
-									escape_sequence_character =
-										iter.next().expect("CSI escape sequence did not terminate");
-									print!("{}", escape_sequence_character);
-									match escape_sequence_character {
+    while let Some(character) = iter.next() {
+        match character {
+            // Consume escape sequences
+            '\x1b' => {
+                // Escape sequences seem to be one of many different categories: https://en.wikipedia.org/wiki/ANSI_escape_code
+                // CSI sequences are \e \[ [bytes in 0x30-0x3F] [bytes in 0x20-0x2F] [final byte in 0x40-0x7E]
+                // nF Escape seq are \e [bytes in 0x20-0x2F] [byte in 0x30-0x7E]
+                // Fp Escape seq are \e [byte in 0x30-0x3F] [I have no idea, but `sl` creates one where the next byte is the end of the escape sequence, so assume that]
+                // Fe Escape seq are \e [byte in 0x40-0x5F] [I have no idea, '' though sl doesn't make one]
+                // Fs Escape seq are \e [byte in 0x60-0x7E] [I have no idea, '' though sl doesn't make one]
+                // Otherwise the next byte is the whole escape sequence (maybe? I can't exactly tell, but I will go with it)
+                // We will consume up to, but not through, the next printable character
+                // In addition, we print everything in the escape sequence, even if it is a color (that will be overriden)
+                print!("\x1b");
+                let mut escape_sequence_character = iter
+                    .next()
+                    .expect("Escape character with no escape sequence after it");
+                print!("{}", escape_sequence_character);
+                match escape_sequence_character {
+                    '[' => loop {
+                        escape_sequence_character =
+                            iter.next().expect("CSI escape sequence did not terminate");
+                        print!("{}", escape_sequence_character);
+                        match escape_sequence_character {
+                            '\x30'..='\x3F' => continue,
+                            '\x20'..='\x2F' => {
+                                loop {
+                                    escape_sequence_character =
+                                        iter.next().expect("CSI escape sequence did not terminate");
+                                    print!("{}", escape_sequence_character);
+                                    match escape_sequence_character {
                             '\x20' ..= '\x2F' => continue,
                             '\x40' ..= '\x7E' => break,
                             _ => panic!("CSI escape sequence terminated with an incorrect value"),
                             }
-								}
-								break;
-							}
-							'\x40'..='\x7E' => break,
-							_ => panic!("CSI escape sequence terminated with an incorrect value"),
-						}
-					},
-					'\x20'..='\x2F' => loop {
-						escape_sequence_character =
-							iter.next().expect("nF escape sequence did not terminate");
-						print!("{}", escape_sequence_character);
-						match escape_sequence_character {
-							'\x20'..='\x2F' => continue,
-							'\x30'..='\x7E' => break,
-							_ => panic!("nF escape sequence terminated with an incorrect value"),
-						}
-					},
-					//            '\x30' ..= '\x3F' => panic!("Fp escape sequences are not supported"),
-					//            '\x40' ..= '\x5F' => panic!("Fe escape sequences are not supported"),
-					//            '\x60' ..= '\x7E' => panic!("Fs escape sequences are not supported"),
-					// be lazy and assume in all other cases we consume exactly 1 byte
-					_ => (),
-				}
-			}
-			// Newlines print escape sequences to end background prints, and in dialup mode sleep, and
-			// reset the seed of the coloring and the value of ignore_whitespace
-			'\n' => {
-				if c.print_color {
-					// Reset the background color only, as we don't have to reset the foreground till
-					// the end of the program
-					// We reset the background here because otherwise it bleeds all the way to the next line
-					if c.background_mode {
-						print!("\x1b[49m");
-					}
-				}
-				println!();
-				if c.dialup_mode {
-					let stall = Duration::from_millis(rand::thread_rng().gen_range(30, 700));
-					sleep(stall);
-				}
+                                }
+                                break;
+                            }
+                            '\x40'..='\x7E' => break,
+                            _ => panic!("CSI escape sequence terminated with an incorrect value"),
+                        }
+                    },
+                    '\x20'..='\x2F' => loop {
+                        escape_sequence_character =
+                            iter.next().expect("nF escape sequence did not terminate");
+                        print!("{}", escape_sequence_character);
+                        match escape_sequence_character {
+                            '\x20'..='\x2F' => continue,
+                            '\x30'..='\x7E' => break,
+                            _ => panic!("nF escape sequence terminated with an incorrect value"),
+                        }
+                    },
+                    //            '\x30' ..= '\x3F' => panic!("Fp escape sequences are not supported"),
+                    //            '\x40' ..= '\x5F' => panic!("Fe escape sequences are not supported"),
+                    //            '\x60' ..= '\x7E' => panic!("Fs escape sequences are not supported"),
+                    // be lazy and assume in all other cases we consume exactly 1 byte
+                    _ => (),
+                }
+            }
+            // Newlines print escape sequences to end background prints, and in dialup mode sleep, and
+            // reset the seed of the coloring and the value of ignore_whitespace
+            '\n' => {
+                if c.print_color {
+                    // Reset the background color only, as we don't have to reset the foreground till
+                    // the end of the program
+                    // We reset the background here because otherwise it bleeds all the way to the next line
+                    if c.background_mode {
+                        print!("\x1b[49m");
+                    }
+                }
+                println!();
+                if c.dialup_mode {
+                    let stall = Duration::from_millis(rand::thread_rng().gen_range(30, 700));
+                    sleep(stall);
+                }
 
-				original_seed += 1.0;
-				c.seed = original_seed; // Reset the seed, but bump it a bit
-				ignore_whitespace = c.background_mode;
-			}
-			// If not an escape sequence or a newline, print a colorful escape sequence and then the
-			// character
-			_ => {
-				// In background mode, don't print colorful whitespace until the first printable character
-				if ignore_whitespace && character.is_whitespace() {
-					print!("{}", character);
-					continue;
-				} else {
-					ignore_whitespace = false;
-				}
+                original_seed += 1.0;
+                c.seed = original_seed; // Reset the seed, but bump it a bit
+                ignore_whitespace = c.background_mode;
+            }
+            // If not an escape sequence or a newline, print a colorful escape sequence and then the
+            // character
+            _ => {
+                // In background mode, don't print colorful whitespace until the first printable character
+                if ignore_whitespace && character.is_whitespace() {
+                    print!("{}", character);
+                    continue;
+                } else {
+                    ignore_whitespace = false;
+                }
 
-				colored_print(character, c);
-				c.seed += 1.0;
-			}
-		}
+                colored_print(character, c);
+                c.seed += 1.0;
+            }
+        }
 
-		// If we should constantly flush, flush after each completed sequence, and also reset
-		// colors because otherwise weird things happen
-		if constantly_flush {
-			reset_colors(c);
-			stdout().flush().unwrap();
-		}
-	}
+        // If we should constantly flush, flush after each completed sequence, and also reset
+        // colors because otherwise weird things happen
+        if constantly_flush {
+            reset_colors(c);
+            stdout().flush().unwrap();
+        }
+    }
 }
 
 fn reset_colors(c: &Control) {
-	if c.print_color {
-		// Reset the background color
-		if c.background_mode {
-			print!("\x1b[49m");
-		}
+    if c.print_color {
+        // Reset the background color
+        if c.background_mode {
+            print!("\x1b[49m");
+        }
 
-		// Reset the foreground color
-		print!("\x1b[39m");
-	}
+        // Reset the foreground color
+        print!("\x1b[39m");
+    }
 }
 
 fn colored_print(character: char, c: &mut Control) {
-	if c.background_mode {
-		let bg = get_color_tuple(c);
-		let fg = calc_fg_color(bg);
-		print!(
-			"\x1b[38;2;{};{};{};48;2;{};{};{}m{}",
-			fg.0, fg.1, fg.2, bg.0, bg.1, bg.2, character
-		);
-	} else {
-		let fg = get_color_tuple(c);
-		print!("\x1b[38;2;{};{};{}m{}", fg.0, fg.1, fg.2, character);
-	}
+    if c.background_mode {
+        let bg = get_color_tuple(c);
+        let fg = calc_fg_color(bg);
+        print!(
+            "\x1b[38;2;{};{};{};48;2;{};{};{}m{}",
+            fg.0, fg.1, fg.2, bg.0, bg.1, bg.2, character
+        );
+    } else {
+        let fg = get_color_tuple(c);
+        print!("\x1b[38;2;{};{};{}m{}", fg.0, fg.1, fg.2, character);
+    }
 }
 
 fn calc_fg_color(bg: (u8, u8, u8)) -> (u8, u8, u8) {
-	// Currently, it only computes the forground clolor based on some threshold
-	// on grayscale value.
-	// TODO: Add a better algorithm for computing forground color
-	if conv_grayscale(bg) > 0xA0_u8 {
-		(0u8, 0u8, 0u8)
-	} else {
-		(0xffu8, 0xffu8, 0xffu8)
-	}
+    // Currently, it only computes the forground clolor based on some threshold
+    // on grayscale value.
+    // TODO: Add a better algorithm for computing forground color
+    if conv_grayscale(bg) > 0xA0_u8 {
+        (0u8, 0u8, 0u8)
+    } else {
+        (0xffu8, 0xffu8, 0xffu8)
+    }
 }
 
 fn linear_to_srgb(intensity: f64) -> f64 {
-	if intensity <= 0.003_130_8 {
-		12.92 * intensity
-	} else {
-		1.055 * intensity.powf(1.0 / 2.4) - 0.055
-	}
+    if intensity <= 0.003_130_8 {
+        12.92 * intensity
+    } else {
+        1.055 * intensity.powf(1.0 / 2.4) - 0.055
+    }
 }
 
 fn srgb_to_linear(intensity: f64) -> f64 {
-	if intensity < 0.04045 {
-		intensity / 12.92
-	} else {
-		((intensity + 0.055) / 1.055).powf(2.4)
-	}
+    if intensity < 0.04045 {
+        intensity / 12.92
+    } else {
+        ((intensity + 0.055) / 1.055).powf(2.4)
+    }
 }
 
 fn conv_grayscale(color: (u8, u8, u8)) -> u8 {
-	// See https://en.wikipedia.org/wiki/Grayscale#Converting_color_to_grayscale
-	const SCALE: f64 = 256.0;
+    // See https://en.wikipedia.org/wiki/Grayscale#Converting_color_to_grayscale
+    const SCALE: f64 = 256.0;
 
-	// Changing SRGB to Linear for gamma correction
-	let red = srgb_to_linear(f64::from(color.0) / SCALE);
-	let green = srgb_to_linear(f64::from(color.1) / SCALE);
-	let blue = srgb_to_linear(f64::from(color.2) / SCALE);
+    // Changing SRGB to Linear for gamma correction
+    let red = srgb_to_linear(f64::from(color.0) / SCALE);
+    let green = srgb_to_linear(f64::from(color.1) / SCALE);
+    let blue = srgb_to_linear(f64::from(color.2) / SCALE);
 
-	// Converting to grayscale
-	let gray_linear = red * 0.299 + green * 0.587 + blue * 0.114;
+    // Converting to grayscale
+    let gray_linear = red * 0.299 + green * 0.587 + blue * 0.114;
 
-	// Gamma correction
-	let gray_srgb = linear_to_srgb(gray_linear);
+    // Gamma correction
+    let gray_srgb = linear_to_srgb(gray_linear);
 
-	(gray_srgb * SCALE) as u8
+    (gray_srgb * SCALE) as u8
 }
 
 fn get_color_tuple(c: &Control) -> (u8, u8, u8) {
-	let i = c.frequency * c.seed / c.spread;
-	let red = i.sin() * 127.00 + 128.00;
-	let green = (i + (std::f64::consts::PI * 2.00 / 3.00)).sin() * 127.00 + 128.00;
-	let blue = (i + (std::f64::consts::PI * 4.00 / 3.00)).sin() * 127.00 + 128.00;
+    let i = c.frequency * c.seed / c.spread;
+    let red = i.sin() * 127.00 + 128.00;
+    let green = (i + (std::f64::consts::PI * 2.00 / 3.00)).sin() * 127.00 + 128.00;
+    let blue = (i + (std::f64::consts::PI * 4.00 / 3.00)).sin() * 127.00 + 128.00;
 
-	(red as u8, green as u8, blue as u8)
+    (red as u8, green as u8, blue as u8)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,149 +14,149 @@ use utf8_chars::BufReadCharsExt;
 mod cat;
 
 fn main() {
-	let mut filename: String = "".to_string();
-	let mut c = parse_cli_args(&mut filename);
+    let mut filename: String = "".to_string();
+    let mut c = parse_cli_args(&mut filename);
 
-	if filename == "" {
-		let stdin = io::stdin(); // For lifetime reasons
-		cat::print_chars_lol(
-			BufReader::new(stdin.lock()).chars().map(|r| r.unwrap()),
-			&mut c,
-			true,
-		);
-	} else if lolcat_file(&filename, &mut c).is_err() {
-		eprintln!("Error opening file {}.", filename)
-	}
+    if filename == "" {
+        let stdin = io::stdin(); // For lifetime reasons
+        cat::print_chars_lol(
+            BufReader::new(stdin.lock()).chars().map(|r| r.unwrap()),
+            &mut c,
+            true,
+        );
+    } else if lolcat_file(&filename, &mut c).is_err() {
+        eprintln!("Error opening file {}.", filename)
+    }
 }
 
 fn lolcat_file(filename: &str, c: &mut cat::Control) -> Result<(), io::Error> {
-	let f = File::open(filename)?;
-	let file = BufReader::new(&f);
-	cat::print_lines_lol(file.lines().map(|r| r.unwrap()), c);
-	Ok(())
+    let f = File::open(filename)?;
+    let file = BufReader::new(&f);
+    cat::print_lines_lol(file.lines().map(|r| r.unwrap()), c);
+    Ok(())
 }
 
 fn parse_cli_args(filename: &mut String) -> cat::Control {
-	let matches = lolcat_clap_app().get_matches();
+    let matches = lolcat_clap_app().get_matches();
 
-	let seed = matches.value_of("seed").unwrap_or("0.0");
-	let spread = matches.value_of("spread").unwrap_or("3.0");
-	let frequency = matches.value_of("frequency").unwrap_or("0.1");
+    let seed = matches.value_of("seed").unwrap_or("0.0");
+    let spread = matches.value_of("spread").unwrap_or("3.0");
+    let frequency = matches.value_of("frequency").unwrap_or("0.1");
 
-	let mut seed: f64 = seed.parse().unwrap();
-	let spread: f64 = spread.parse().unwrap();
-	let frequency: f64 = frequency.parse().unwrap();
+    let mut seed: f64 = seed.parse().unwrap();
+    let spread: f64 = spread.parse().unwrap();
+    let frequency: f64 = frequency.parse().unwrap();
 
-	if seed == 0.0 {
-		seed = rand::random::<f64>() * 10e9;
-	}
+    if seed == 0.0 {
+        seed = rand::random::<f64>() * 10e9;
+    }
 
-	*filename = matches.value_of("filename").unwrap_or("").to_string();
+    *filename = matches.value_of("filename").unwrap_or("").to_string();
 
-	let print_color = matches.is_present("force-color") || atty::is(Stream::Stdout);
+    let print_color = matches.is_present("force-color") || atty::is(Stream::Stdout);
 
-	let mut retval = cat::Control {
-		seed,
-		spread,
-		frequency,
-		background_mode: matches.is_present("background"),
-		dialup_mode: matches.is_present("dialup"),
-		print_color: print_color,
-	};
+    let mut retval = cat::Control {
+        seed,
+        spread,
+        frequency,
+        background_mode: matches.is_present("background"),
+        dialup_mode: matches.is_present("dialup"),
+        print_color: print_color,
+    };
 
-	if matches.is_present("help") {
-		print_rainbow_help(false, &mut retval);
-		std::process::exit(0);
-	}
-	if matches.is_present("version") {
-		print_rainbow_help(true, &mut retval);
-		std::process::exit(0);
-	}
+    if matches.is_present("help") {
+        print_rainbow_help(false, &mut retval);
+        std::process::exit(0);
+    }
+    if matches.is_present("version") {
+        print_rainbow_help(true, &mut retval);
+        std::process::exit(0);
+    }
 
-	retval
+    retval
 }
 
 fn print_rainbow_help(only_version: bool, c: &mut cat::Control) {
-	let app = lolcat_clap_app();
+    let app = lolcat_clap_app();
 
-	let mut help = Vec::new();
-	if only_version {
-		app.write_version(&mut help).unwrap();
-	} else {
-		app.write_help(&mut help).unwrap();
-	}
-	let help = String::from_utf8(help).unwrap();
+    let mut help = Vec::new();
+    if only_version {
+        app.write_version(&mut help).unwrap();
+    } else {
+        app.write_help(&mut help).unwrap();
+    }
+    let help = String::from_utf8(help).unwrap();
 
-	cat::print_lines_lol(help.lines(), c);
+    cat::print_lines_lol(help.lines(), c);
 }
 
 fn lolcat_clap_app() -> App<'static, 'static> {
-	App::new("lolcat")
-		.version(env!("CARGO_PKG_VERSION"))
-		.author(env!("CARGO_PKG_AUTHORS"))
-		.about(env!("CARGO_PKG_DESCRIPTION"))
-		.arg(
-			Arg::with_name("seed")
-				.short("s")
-				.long("seed")
-				.help("A seed for your lolcat. Setting this to 0 randomizes the seed.")
-				.takes_value(true),
-		)
-		.arg(
-			Arg::with_name("spread")
-				.short("S")
-				.long("spread")
-				.help("How much should we spread dem colors? Defaults to 3.0")
-				.takes_value(true),
-		)
-		.arg(
-			Arg::with_name("frequency")
-				.short("f")
-				.long("frequency")
-				.help("Frequency - used in our math. Defaults to 0.1")
-				.takes_value(true),
-		)
-		.arg(
-			Arg::with_name("background")
-				.short("B")
-				.long("bg")
-				.help("Background mode - If selected the background will be rainbow. Default false")
-				.takes_value(false),
-		)
-		.arg(
-			Arg::with_name("dialup")
-				.short("D")
-				.long("dialup")
-				.help("Dialup mode - Simulate dialup connection")
-				.takes_value(false),
-		)
-		.arg(
-			Arg::with_name("force-color")
-				.short("F")
-				.long("force-color")
-				.help("Force color - Print escape sequences even if the output is not a terminal")
-				.takes_value(false),
-		)
-		.arg(
-			Arg::with_name("filename")
-				.short("i")
-				.long("input file name")
-				.help("Lolcat this file. Reads from STDIN if missing")
-				.takes_value(true)
-				.index(1),
-		)
-		.arg(
-			Arg::with_name("help")
-				.short("h")
-				.long("help")
-				.help("Prints help information")
-				.takes_value(false),
-		)
-		.arg(
-			Arg::with_name("version")
-				.short("V")
-				.long("version")
-				.help("Prints version information")
-				.takes_value(false),
-		)
+    App::new("lolcat")
+        .version(env!("CARGO_PKG_VERSION"))
+        .author(env!("CARGO_PKG_AUTHORS"))
+        .about(env!("CARGO_PKG_DESCRIPTION"))
+        .arg(
+            Arg::with_name("seed")
+                .short("s")
+                .long("seed")
+                .help("A seed for your lolcat. Setting this to 0 randomizes the seed.")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("spread")
+                .short("S")
+                .long("spread")
+                .help("How much should we spread dem colors? Defaults to 3.0")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("frequency")
+                .short("f")
+                .long("frequency")
+                .help("Frequency - used in our math. Defaults to 0.1")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("background")
+                .short("B")
+                .long("bg")
+                .help("Background mode - If selected the background will be rainbow. Default false")
+                .takes_value(false),
+        )
+        .arg(
+            Arg::with_name("dialup")
+                .short("D")
+                .long("dialup")
+                .help("Dialup mode - Simulate dialup connection")
+                .takes_value(false),
+        )
+        .arg(
+            Arg::with_name("force-color")
+                .short("F")
+                .long("force-color")
+                .help("Force color - Print escape sequences even if the output is not a terminal")
+                .takes_value(false),
+        )
+        .arg(
+            Arg::with_name("filename")
+                .short("i")
+                .long("input file name")
+                .help("Lolcat this file. Reads from STDIN if missing")
+                .takes_value(true)
+                .index(1),
+        )
+        .arg(
+            Arg::with_name("help")
+                .short("h")
+                .long("help")
+                .help("Prints help information")
+                .takes_value(false),
+        )
+        .arg(
+            Arg::with_name("version")
+                .short("V")
+                .long("version")
+                .help("Prints version information")
+                .takes_value(false),
+        )
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,8 @@ extern crate clap;
 extern crate rand;
 extern crate utf8_chars;
 
-use clap::{App, Arg};
 use atty::Stream;
+use clap::{App, Arg};
 use std::fs::File;
 use std::io;
 use std::io::BufRead;
@@ -14,146 +14,149 @@ use utf8_chars::BufReadCharsExt;
 mod cat;
 
 fn main() {
-    let mut filename: String = "".to_string();
-    let mut c = parse_cli_args(&mut filename);
+	let mut filename: String = "".to_string();
+	let mut c = parse_cli_args(&mut filename);
 
-    if filename == "" {
-        let stdin = io::stdin(); // For lifetime reasons
-        cat::print_chars_lol(BufReader::new(stdin.lock()).chars().map(|r| r.unwrap()), &mut c, true);
-    } else if lolcat_file(&filename, &mut c).is_err() {
-        eprintln!("Error opening file {}.", filename)
-    }
+	if filename == "" {
+		let stdin = io::stdin(); // For lifetime reasons
+		cat::print_chars_lol(
+			BufReader::new(stdin.lock()).chars().map(|r| r.unwrap()),
+			&mut c,
+			true,
+		);
+	} else if lolcat_file(&filename, &mut c).is_err() {
+		eprintln!("Error opening file {}.", filename)
+	}
 }
 
 fn lolcat_file(filename: &str, c: &mut cat::Control) -> Result<(), io::Error> {
-    let f = File::open(filename)?;
-    let file = BufReader::new(&f);
-    cat::print_lines_lol(file.lines().map(|r| r.unwrap()), c);
-    Ok(())
+	let f = File::open(filename)?;
+	let file = BufReader::new(&f);
+	cat::print_lines_lol(file.lines().map(|r| r.unwrap()), c);
+	Ok(())
 }
 
 fn parse_cli_args(filename: &mut String) -> cat::Control {
-    let matches = lolcat_clap_app()
-        .get_matches();
+	let matches = lolcat_clap_app().get_matches();
 
-    let seed = matches.value_of("seed").unwrap_or("0.0");
-    let spread = matches.value_of("spread").unwrap_or("3.0");
-    let frequency = matches.value_of("frequency").unwrap_or("0.1");
+	let seed = matches.value_of("seed").unwrap_or("0.0");
+	let spread = matches.value_of("spread").unwrap_or("3.0");
+	let frequency = matches.value_of("frequency").unwrap_or("0.1");
 
-    let mut seed: f64 = seed.parse().unwrap();
-    let spread: f64 = spread.parse().unwrap();
-    let frequency: f64 = frequency.parse().unwrap();
+	let mut seed: f64 = seed.parse().unwrap();
+	let spread: f64 = spread.parse().unwrap();
+	let frequency: f64 = frequency.parse().unwrap();
 
-    if seed == 0.0 {
-        seed = rand::random::<f64>() * 10e9;
-    }
+	if seed == 0.0 {
+		seed = rand::random::<f64>() * 10e9;
+	}
 
-    *filename = matches.value_of("filename").unwrap_or("").to_string();
+	*filename = matches.value_of("filename").unwrap_or("").to_string();
 
-    let print_color = matches.is_present("force-color") || atty::is(Stream::Stdout);
+	let print_color = matches.is_present("force-color") || atty::is(Stream::Stdout);
 
-    let mut retval = cat::Control {
-        seed,
-        spread,
-        frequency,
-        background_mode: matches.is_present("background"),
-        dialup_mode: matches.is_present("dialup"),
-        print_color: print_color,
-    };
+	let mut retval = cat::Control {
+		seed,
+		spread,
+		frequency,
+		background_mode: matches.is_present("background"),
+		dialup_mode: matches.is_present("dialup"),
+		print_color: print_color,
+	};
 
-    if matches.is_present("help") {
-        print_rainbow_help(false, &mut retval);
-        std::process::exit(0);
-    }
-    if matches.is_present("version") {
-        print_rainbow_help(true, &mut retval);
-        std::process::exit(0);
-    }
+	if matches.is_present("help") {
+		print_rainbow_help(false, &mut retval);
+		std::process::exit(0);
+	}
+	if matches.is_present("version") {
+		print_rainbow_help(true, &mut retval);
+		std::process::exit(0);
+	}
 
-    retval
+	retval
 }
 
 fn print_rainbow_help(only_version: bool, c: &mut cat::Control) {
-    let app = lolcat_clap_app();
+	let app = lolcat_clap_app();
 
-    let mut help = Vec::new();
-    if only_version {
-        app.write_version(&mut help).unwrap();
-    } else {
-        app.write_help(&mut help).unwrap();
-    }
-    let help = String::from_utf8(help).unwrap();
+	let mut help = Vec::new();
+	if only_version {
+		app.write_version(&mut help).unwrap();
+	} else {
+		app.write_help(&mut help).unwrap();
+	}
+	let help = String::from_utf8(help).unwrap();
 
-    cat::print_lines_lol(help.lines(), c);
+	cat::print_lines_lol(help.lines(), c);
 }
 
 fn lolcat_clap_app() -> App<'static, 'static> {
-    App::new("lolcat")
-        .version(env!("CARGO_PKG_VERSION"))
-        .author(env!("CARGO_PKG_AUTHORS"))
-        .about(env!("CARGO_PKG_DESCRIPTION"))
-        .arg(
-            Arg::with_name("seed")
-                .short("s")
-                .long("seed")
-                .help("A seed for your lolcat. Setting this to 0 randomizes the seed.")
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name("spread")
-                .short("S")
-                .long("spread")
-                .help("How much should we spread dem colors? Defaults to 3.0")
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name("frequency")
-                .short("f")
-                .long("frequency")
-                .help("Frequency - used in our math. Defaults to 0.1")
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name("background")
-                .short("B")
-                .long("bg")
-                .help("Background mode - If selected the background will be rainbow. Default false")
-                .takes_value(false),
-        )
-        .arg(
-            Arg::with_name("dialup")
-                .short("D")
-                .long("dialup")
-                .help("Dialup mode - Simulate dialup connection")
-                .takes_value(false),
-        )
-        .arg(
-            Arg::with_name("force-color")
-                .short("F")
-                .long("force-color")
-                .help("Force color - Print escape sequences even if the output is not a terminal")
-                .takes_value(false),
-        )
-        .arg(
-            Arg::with_name("filename")
-                .short("i")
-                .long("input file name")
-                .help("Lolcat this file. Reads from STDIN if missing")
-                .takes_value(true)
-                .index(1),
-        )
-        .arg(
-            Arg::with_name("help")
-                .short("h")
-                .long("help")
-                .help("Prints help information")
-                .takes_value(false)
-        )
-        .arg(
-            Arg::with_name("version")
-                .short("V")
-                .long("version")
-                .help("Prints version information")
-                .takes_value(false)
-        )
+	App::new("lolcat")
+		.version(env!("CARGO_PKG_VERSION"))
+		.author(env!("CARGO_PKG_AUTHORS"))
+		.about(env!("CARGO_PKG_DESCRIPTION"))
+		.arg(
+			Arg::with_name("seed")
+				.short("s")
+				.long("seed")
+				.help("A seed for your lolcat. Setting this to 0 randomizes the seed.")
+				.takes_value(true),
+		)
+		.arg(
+			Arg::with_name("spread")
+				.short("S")
+				.long("spread")
+				.help("How much should we spread dem colors? Defaults to 3.0")
+				.takes_value(true),
+		)
+		.arg(
+			Arg::with_name("frequency")
+				.short("f")
+				.long("frequency")
+				.help("Frequency - used in our math. Defaults to 0.1")
+				.takes_value(true),
+		)
+		.arg(
+			Arg::with_name("background")
+				.short("B")
+				.long("bg")
+				.help("Background mode - If selected the background will be rainbow. Default false")
+				.takes_value(false),
+		)
+		.arg(
+			Arg::with_name("dialup")
+				.short("D")
+				.long("dialup")
+				.help("Dialup mode - Simulate dialup connection")
+				.takes_value(false),
+		)
+		.arg(
+			Arg::with_name("force-color")
+				.short("F")
+				.long("force-color")
+				.help("Force color - Print escape sequences even if the output is not a terminal")
+				.takes_value(false),
+		)
+		.arg(
+			Arg::with_name("filename")
+				.short("i")
+				.long("input file name")
+				.help("Lolcat this file. Reads from STDIN if missing")
+				.takes_value(true)
+				.index(1),
+		)
+		.arg(
+			Arg::with_name("help")
+				.short("h")
+				.long("help")
+				.help("Prints help information")
+				.takes_value(false),
+		)
+		.arg(
+			Arg::with_name("version")
+				.short("V")
+				.long("version")
+				.help("Prints version information")
+				.takes_value(false),
+		)
 }


### PR DESCRIPTION
Simple performance checking indicates this is around 1.1 ± 0.2 times slower than before. I think it doesn't matter as much as the feature does, though.

I might investigate adding a flag for fast printing without that. The binary is already huge (from library code I think) so duplicating the functions a few times probably won't affect it too much.

I will also look into adding a flag for word wrapping, so that space-separated strings are always printed on the same line when possible. That seems useful for human-readable use. I'm not sure if I should make it default though - it will be probably be significantly slower.