### PR TITLE
Word wrap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,7 +93,7 @@ checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "lolcat"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "atty",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lolcat"
-version = "1.5.0"
+version = "1.5.1"
 authors = ["Umang Raghuvanshi <u@umangis.me>"]
 description = "The good ol' lolcat, now with fearless concurrency."
 license = "MIT"

--- a/src/cat.rs
+++ b/src/cat.rs
@@ -210,14 +210,15 @@ pub fn generic_print_chars_lol<
                             &mut printed_chars_on_line,
                         );
                         word_wrap_buffer_chars = 0;
+                    } else {
+                        print_char_lol::<LINE_WRAP, WORD_WRAP>(
+                            character,
+                            c,
+                            &mut seed_at_start_of_line,
+                            &mut ignoring_whitespace,
+                            &mut printed_chars_on_line,
+                        );
                     }
-                    print_char_lol::<LINE_WRAP, WORD_WRAP>(
-                        character,
-                        c,
-                        &mut seed_at_start_of_line,
-                        &mut ignoring_whitespace,
-                        &mut printed_chars_on_line,
-                    );
                 } else {
                     print_char_lol::<LINE_WRAP, WORD_WRAP>(
                         character,
@@ -321,7 +322,6 @@ fn print_word_lol(
             ignoring_whitespace,
             printed_chars_on_line,
         );
-        *word_wrap_buffer_chars = 0;
     }
     // In background mode, don't print colorful whitespace until the first printable character
     if *ignoring_whitespace {

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,8 +87,6 @@ fn parse_cli_args(filename: &mut String) -> cat::Control {
         .parse()
         .unwrap_or(!is_stdout(&filename));
 
-    println!("Is word_wrap : {}", word_wrap);
-
     let mut retval = cat::Control {
         seed,
         spread,

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ fn main() {
     let mut filename: String = "".to_string();
     let mut c = parse_cli_args(&mut filename);
 
-    if is_stdout(&filename) {
+    if is_stdin(&filename) {
         let stdin = io::stdin(); // For lifetime reasons
         cat::print_chars_lol(
             BufReader::new(stdin.lock()).chars().map(|r| r.unwrap()),
@@ -37,7 +37,7 @@ fn lolcat_file(filename: &str, c: &mut cat::Control) -> Result<(), io::Error> {
     Ok(())
 }
 
-fn is_stdout(filename: &String) -> bool {
+fn is_stdin(filename: &String) -> bool {
     filename == ""
 }
 
@@ -85,7 +85,7 @@ fn parse_cli_args(filename: &mut String) -> cat::Control {
         .value_of("word-wrap")
         .unwrap_or("")
         .parse()
-        .unwrap_or(!is_stdout(&filename));
+        .unwrap_or(!is_stdin(&filename));
 
     let mut retval = cat::Control {
         seed,

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,10 +56,9 @@ fn parse_cli_args(filename: &mut String) -> cat::Control {
 
     let print_color = matches.is_present("force-color") || atty::is(Stream::Stdout);
 
-	// If the terminal width is passed, use that. Else, get the size of the terminal. Else, use 0 (no overflow)
-    let terminal_width: Result<u16, ParseIntError> = matches.value_of("width")
-        .unwrap_or("")
-        .parse();
+    // If the terminal width is passed, use that. Else, get the size of the terminal. Else, use 0 (no overflow)
+    let terminal_width: Result<u16, ParseIntError> =
+        matches.value_of("width").unwrap_or("").parse();
     let terminal_width: u16 = match terminal_width {
         Ok(width) => width,
         Err(_) => {
@@ -71,6 +70,9 @@ fn parse_cli_args(filename: &mut String) -> cat::Control {
         }
     };
 
+    let line_wrap = !matches.is_present("no-line-wrap");
+    let word_wrap = !matches.is_present("no-word-wrap");
+
     let mut retval = cat::Control {
         seed,
         spread,
@@ -79,6 +81,8 @@ fn parse_cli_args(filename: &mut String) -> cat::Control {
         dialup_mode: matches.is_present("dialup"),
         print_color: print_color,
         terminal_width_plus_one: terminal_width.wrapping_add(1),
+        line_wrap: line_wrap,
+        word_wrap: word_wrap,
     };
 
     if matches.is_present("help") {
@@ -159,6 +163,18 @@ fn lolcat_clap_app() -> App<'static, 'static> {
                 .long("terminal-width")
                 .help("Terminal width - Set a custom terminal wrapping width, or 0 for unlimited")
                 .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("no-line-wrap")
+                .long("no-line-wrap")
+                .help("Disables smart line wrapping behavior for blazingly unsafe performance")
+                .takes_value(false),
+        )
+        .arg(
+            Arg::with_name("no-word-wrap")
+                .long("no-word-wrap")
+                .help("Disables smart word wrapping behavior as it might be annoying in some cases")
+                .takes_value(false),
         )
         .arg(
             Arg::with_name("filename")


### PR DESCRIPTION
I am not going to merge this yet because it makes a potentially very undesirable change: It makes lolcat automatically wrap words. Words are defined as space-separated strings. So

```
$ echo words that are awesome and very cool and all on one line including one super long word: aoeushaeoshusaohueoahush > test_file
$ lolcat --terminal-size 10 test_file
```

prints

```
words 
that are 
awesome 
and very 
cool and 
all on 
one line 
including
one super
long 
word: 
aoeushaeo
shusaohue
oahush
```

`lolcat` is about printing (fun) things for humans. So I think reflowing output is not necessarily a bad thing. But it may be very different from what is expected for a drop-in replacement for the original `lolcat`. Therefore it might be wiser to put it behind a `-w` flag to turn it on.

However, I think also that making useful upgrades require random command-line flags to turn on is silly and a big part of why people love `ripgrep` and `bat` and `exa` etc.

I do think that the only output which this particularly breaks is probably already broken though. So I am in favor of it myself, just don't want to make such a change randomly.

Therefore, I am conflicted. I would like feedback on whether this should be merged or not. @ur0