### PR TITLE
Improve error handling & fix clippy lints

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ fn main() {
     let mut filename: String = "".to_string();
     let mut c = parse_cli_args(&mut filename);
 
-    if filename == "" {
+    if filename.is_empty() {
         let stdin = io::stdin(); // For lifetime reasons
         cat::print_chars_lol(
             BufReader::new(stdin.lock()).chars().map(|r| r.unwrap()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,8 @@ use utf8_chars::BufReadCharsExt;
 
 mod cat;
 
+const UTF_8_REPLACEMENT: char = '\u{FFFD}';
+
 fn main() {
     let mut filename: String = "".to_string();
     let mut c = parse_cli_args(&mut filename);
@@ -20,7 +22,7 @@ fn main() {
     if filename.is_empty() {
         let stdin = io::stdin(); // For lifetime reasons
         cat::print_chars_lol(
-            BufReader::new(stdin.lock()).chars().map(|r| r.unwrap()),
+            BufReader::new(stdin.lock()).chars().map(|r| r.unwrap_or(UTF_8_REPLACEMENT)),
             &mut c,
             true,
         );
@@ -32,7 +34,7 @@ fn main() {
 fn lolcat_file(filename: &str, c: &mut cat::Control) -> Result<(), io::Error> {
     let f = File::open(filename)?;
     let file = BufReader::new(&f);
-    cat::print_lines_lol(file.lines().map(|r| r.unwrap()), c);
+    cat::print_lines_lol(file.lines().map(|r| r.unwrap_or(UTF_8_REPLACEMENT.to_string())), c);
     Ok(())
 }
 


### PR DESCRIPTION
In this pull request, I first updated the source according to the clippy lint [comparison_to_empty](https://rust-lang.github.io/rust-clippy/master/index.html#/comparison_to_empty), which can be a lot faster than using the equality operator. 

I also "fixed" the issue #29 with improved error handling. I was not able to fix the root cause, being an invalid utf-8 character. But before the program would just panic, whereas now, it prints the replacement character: U+FFFD instead.